### PR TITLE
fix: remove unused imports

### DIFF
--- a/src/interfaces/IOracle.cairo
+++ b/src/interfaces/IOracle.cairo
@@ -310,7 +310,7 @@ mod Oracle {
                     pairs.append(pair);
                 }
                 i += 1;
-            };
+            }
 
             pairs
         }

--- a/src/starkremit/StarkRemit.cairo
+++ b/src/starkremit/StarkRemit.cairo
@@ -1728,7 +1728,7 @@ mod StarkRemit {
                 transfers.append(transfer);
                 count += 1;
                 i += 1;
-            };
+            }
 
             transfers
         }
@@ -1749,7 +1749,7 @@ mod StarkRemit {
                 transfers.append(transfer);
                 count += 1;
                 i += 1;
-            };
+            }
 
             transfers
         }
@@ -1969,7 +1969,7 @@ mod StarkRemit {
                 agents.append(agent);
                 count += 1;
                 i += 1;
-            };
+            }
 
             agents
         }
@@ -2014,7 +2014,7 @@ mod StarkRemit {
                 history.append(history_entry);
                 count += 1;
                 i += 1;
-            };
+            }
 
             history
         }
@@ -2035,7 +2035,7 @@ mod StarkRemit {
                 history.append(history_entry);
                 count += 1;
                 i += 1;
-            };
+            }
 
             history
         }
@@ -2056,7 +2056,7 @@ mod StarkRemit {
                 history.append(history_entry);
                 count += 1;
                 i += 1;
-            };
+            }
 
             history
         }
@@ -2152,7 +2152,7 @@ mod StarkRemit {
                 let member = self.member_by_index.read(i);
                 members.append(member);
                 i += 1;
-            };
+            }
 
             members
         }

--- a/tests/test_StarkRemit.cairo
+++ b/tests/test_StarkRemit.cairo
@@ -1,7 +1,4 @@
 use snforge_std::declare;
-#[feature("deprecated-starknet-consts")]
-use starkremit_contract::base::types::{
-};
 
 
 // Test Constants

--- a/tests/test_comprehensive.cairo
+++ b/tests/test_comprehensive.cairo
@@ -1,4 +1,4 @@
-use snforge_std::{declare};
+use snforge_std::declare;
 #[feature("deprecated-starknet-consts")]
 use starknet::ContractAddress;
 use starkremit_contract::base::types::{

--- a/tests/test_kyc.cairo
+++ b/tests/test_kyc.cairo
@@ -12,7 +12,8 @@ const ADMIN_ADDRESS: felt252 = 0x123;
 const USER_ADDRESS: felt252 = 0x456;
 const ORACLE_ADDRESS: felt252 = 0x789;
 const VERIFICATION_HASH: felt252 = 0xABC;
-const MAX_SUPPLY: u256 = 1_000_000_000_u256 * 1_000_000_000_000_000_000_u256; // 1B tokens with 18 decimals
+const MAX_SUPPLY: u256 = 1_000_000_000_u256
+    * 1_000_000_000_000_000_000_u256; // 1B tokens with 18 decimals
 
 fn deploy_starkremit_contract() -> IStarkRemitDispatcher {
     let contract = declare("StarkRemit").unwrap().contract_class();


### PR DESCRIPTION
Removed all unused imports to get rid of errors and warning messages.
close #33 