### PR TITLE
fix: enforce KYC validation in requestLoan and add comprehensive tests

### DIFF
--- a/src/starkremit/StarkRemit.cairo
+++ b/src/starkremit/StarkRemit.cairo
@@ -1630,7 +1630,12 @@ pub mod StarkRemit {
             // Validate caller is not zero address
             assert(!caller.is_zero(), RegistrationErrors::ZERO_ADDRESS);
             // assert(self.is_user_registered(requester), RegistrationErrors::USER_NOT_FOUND);
-            // assert(self.is_kyc_valid(requester), KYCErrors::INVALID_KYC_STATUS);
+
+            // Conditional KYC validation
+            if self.kyc_enforcement_enabled.read() {
+                assert(self.is_kyc_valid(requester), KYCErrors::INVALID_KYC_STATUS);
+            }
+
             assert(amount > 0, 'loan amount is zero');
             // Ensure the user has no active loans
             assert(!self.active_loan.read(requester), 'User already has an active loan');


### PR DESCRIPTION
What does this PR do?

Enforces KYC validation in the requestLoan function, ensuring users without valid KYC cannot request loans when enforcement is enabled.
Makes KYC validation conditional based on the kyc_enforcement_enabled flag.
Adds comprehensive tests for all KYC enforcement scenarios (valid, invalid, expired, suspended, enforcement toggled on/off).



Acceptance Criteria
[x] KYC validation is enforced in requestLoan when enforcement is enabled.
[x] Users without valid KYC are rejected with the correct error.
[x] Tests cover all KYC enforcement scenarios.
[x] Code is formatted and builds successfully.

How was this tested?
Added and ran new tests in tests/test_loan.cairo for:
KYC enforcement enabled/disabled
Valid, invalid, expired, and suspended KYC statuses
Confirmed contract builds and formats with scarb build and scarb fmt.
